### PR TITLE
fix: carsh in showLocalNotifaction caused by "This coder only encodes objects that adopt NSSecureCoding"

### DIFF
--- a/AgoraChat-Swift/AgoraChat-Swift/code/Controllers/AgoraMainViewController.swift
+++ b/AgoraChat-Swift/AgoraChat-Swift/code/Controllers/AgoraMainViewController.swift
@@ -164,7 +164,7 @@ class AgoraMainViewController: UITabBarController {
         }
         
         let userInfo: [String: Any] = [
-            "MessageType": message.chatType,
+            "MessageType": message.chatType.rawValue,
             "ConversationChatter": message.conversationId
         ]
     


### PR DESCRIPTION

<img width="1220" alt="WeChatWorkScreenshot_df41d6f0-f33f-4738-b36b-45a44dcd726e" src="https://github.com/AgoraIO-Usecase/AgoraChat-ios/assets/123744402/68af2799-6ab9-45f8-b25f-e646f41bf350">
